### PR TITLE
Trim browser-use debug logs

### DIFF
--- a/browser_use_runner_lib.py
+++ b/browser_use_runner_lib.py
@@ -38,7 +38,8 @@ class LogCapture:
         self.original_handlers = {}
         self.string_io = io.StringIO()
         self.handler = logging.StreamHandler(self.string_io)
-        self.handler.setLevel(logging.DEBUG)  # Capture all levels
+        # Capture logs at INFO level and above
+        self.handler.setLevel(logging.INFO)
 
         # Create a custom formatter to ensure we get all the info
         formatter = logging.Formatter("%(levelname)s     [%(name)s] %(message)s")
@@ -61,9 +62,9 @@ class LogCapture:
             self.original_handlers[logger_name] = log.handlers.copy()
             # Add our capturing handler
             log.addHandler(self.handler)
-            # Ensure the logger level is low enough to capture everything
-            if log.level > logging.DEBUG:
-                log.setLevel(logging.DEBUG)
+            # Capture at INFO level by default
+            if log.level > logging.INFO:
+                log.setLevel(logging.INFO)
 
         return self
 
@@ -91,11 +92,8 @@ def parse_agent_logs(
     task_completed_successfully = False
     task_failed = False
 
-    # Debug: Print all captured logs to see what we're working with
+    # Log the amount of information captured for troubleshooting
     logger.info(f"[PARSE] Processing {len(logs)} log lines for scenario: {scenario}")
-    for i, log_line in enumerate(logs):
-        if log_line.strip():
-            logger.debug(f"[PARSE] Log {i}: {log_line}")
 
     for log_line in logs:
         if not log_line.strip():

--- a/executor.py
+++ b/executor.py
@@ -55,7 +55,6 @@ def run_test_steps(steps, scenario="Unnamed scenario"):
                     found_items = page.locator(
                         ".cart_item .inventory_item_name"
                     ).all_text_contents()
-                    print(f"[DEBUG] Cart contains: {found_items}")
                     for item in expected_items:
                         assert item in found_items, f"'{item}' not found in cart"
 

--- a/jira_agent_backend.py
+++ b/jira_agent_backend.py
@@ -80,7 +80,6 @@ def suggest_scenarios():
             f"{jira._options['server']}/rest/api/3/issue/{subtask_key}/assignee",
             json={"accountId": qa_user_id},
         )
-        print(f"[DEBUG] Assign issue response: {resp.status_code} - {resp.text}")
         print(f"[JIRA] 👤 Assigned subtask {subtask_key} to QA user.")
 
         mention = {

--- a/jira_writer.py
+++ b/jira_writer.py
@@ -375,13 +375,7 @@ def format_test_results(
             # Run the test
             result_obj = runner(context, name)
 
-            # Debug: Print the result_obj structure
-            print(f"[DEBUG] Result object type: {type(result_obj)}")
-            print(
-                f"[DEBUG] Result object attributes: {dir(result_obj) if hasattr(result_obj, '__dict__') else 'N/A'}"
-            )
-            if hasattr(result_obj, "success"):
-                print(f"[DEBUG] Success field value: {result_obj.success}")
+            # Debug information for troubleshooting
 
             # Handle ScenarioResult object - FIXED LOGIC
             if hasattr(result_obj, "results"):
@@ -401,14 +395,10 @@ def format_test_results(
             # Method 1: Check the success field if it exists
             if hasattr(result_obj, "success"):
                 scenario_passed = result_obj.success
-                print(f"[DEBUG] Using success field: {scenario_passed}")
 
             # Method 2: Check if final result indicates success
             elif final_result and "successfully" in final_result.lower():
                 scenario_passed = True
-                print(
-                    f"[DEBUG] Using final_result success indicator: {scenario_passed}"
-                )
 
             # Method 3: Check if there's a "Task completion" step with "passed" status
             elif scenario_results:
@@ -417,7 +407,6 @@ def format_test_results(
                     step_status = getattr(step, "status", "")
                     if "Task completion" in step_name and step_status == "passed":
                         scenario_passed = True
-                        print(f"[DEBUG] Found task completion step with passed status")
                         break
 
             # Method 4: Check logs for task completion indicators

--- a/nlp_parser.py
+++ b/nlp_parser.py
@@ -48,7 +48,6 @@ If the story doesn't describe test flows clearly, invent 2–3 possible flows th
             temperature=0.2,
         )
         content = response.choices[0].message.content
-        print("\n[DEBUG] GPT Response:\n", content)
 
         match = re.search(r"```json\s*(\[.*?\])\s*```", content, re.DOTALL)
         if not match:


### PR DESCRIPTION
## Summary
- keep LogCapture at INFO level only
- strip leftover debug prints

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'nest_asyncio')*
